### PR TITLE
Enhanced copy-object

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -232,16 +232,16 @@
         (throw e)))))
 
 (defn copy-object
-  "Copy an existing S3 object to another key.
-
-   TODO add destructive :overwrite option for meta."
+  "Copy an existing S3 object to another key."
   ([cred bucket src-key dest-key]
      (copy-object cred bucket src-key bucket dest-key))
   ([cred src-bucket src-key dest-bucket dest-key]
-     (copy-object src-bucket src-key dest-bucket dest-key {}))
-  ([cred src-bucket src-key dest-bucket dest-key newmeta]
+     (copy-object src-bucket src-key dest-bucket dest-key {} true))
+  ([cred src-bucket src-key dest-bucket dest-key newmeta keepmeta?]
      (let [acl (get-object-acl cred src-bucket src-key)
-           ometa (get-object-meta cred src-bucket src-key)
+           ometa (if keepmeta?
+                   (get-object-meta cred src-bucket src-key)
+                   (ObjectMetadata.))
            cobj (CopyObjectRequest. src-bucket src-key
                                     dest-bucket dest-key)]
        (doseq [[k v] newmeta]


### PR DESCRIPTION
I needed the ability to perform a copy-in-place for the purposes of updating metadata on an object.  This is S3's sanctioned (and only) way to update, for example, x-amz-meta headers.

I don't love the impl mainly because the args to copy-object are getting a bit unwieldy, but functionally it does what I want.  Would appreciate you considering it or something like it in the codebase.
