### PR TITLE
Include metadata when you put a file

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -126,7 +126,9 @@
   [bucket key request]
   (cond
    (:file request)
-     (PutObjectRequest. bucket key (:file request))
+     (let [put-obj-req (PutObjectRequest. bucket key (:file request))]
+       (.setMetadata put-obj-req (map->ObjectMetadata (dissoc request :file)))
+       put-obj-req)
    (:input-stream request)
      (PutObjectRequest.
       bucket key


### PR DESCRIPTION
This associates the metadata with the put object request instead of silently discarding it
