### PR TITLE
bug: content-length is count of characters

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -90,7 +90,7 @@
   String
   (put-request [s]
     {:input-stream     (ByteArrayInputStream. (.getBytes s))
-     :content-length   (count s)
+     :content-length   (count (.getBytes s))
      :content-encoding (.name (Charset/defaultCharset))}))
 
 (defmacro set-attr


### PR DESCRIPTION
Hey, I got bit by this and thought I'd update it.  In the S3 put, you're counting the characters and not the byte-stream, which cause errors if you've got some Unicode characters.

BTW: I did exactly the same thing in MY debug code: (count unicode-foo)  :-)  Great tool! 
