### PR TITLE
Use `:content-type` in `String` implementation of `ToPutRequest`

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -89,9 +89,10 @@
   (put-request [f] {:file f})
   String
   (put-request [s]
-    {:input-stream     (ByteArrayInputStream. (.getBytes s))
-     :content-length   (count (.getBytes s))
-     :content-encoding (.name (Charset/defaultCharset))}))
+    (let [bytes (.getBytes s)]
+      {:input-stream     (ByteArrayInputStream. bytes)
+       :content-length   (count bytes)
+       :content-type     (str "text/plain; charset=" (.name (Charset/defaultCharset)))})))
 
 (defmacro set-attr
   "Set an attribute on an object if not nil."
@@ -146,7 +147,7 @@
   following keys:
     :cache-control          - the cache-control header (see RFC 2616)
     :content-disposition    - how the content should be downloaded by browsers
-    :content-encoding       - the character encoding of the content
+    :content-encoding       - the encoding of the content (e.g. gzip)
     :content-length         - the length of the content in bytes
     :content-md5            - the MD5 sum of the content
     :content-type           - the mime type of the content


### PR DESCRIPTION
Rather than setting the text encoding via the `:content-encoding`
option / header (specifiying a text encoding here is invalid; see RFC
2616, section 3.5 for valid values) the `:content-type` option with a
value of `text/plain` and a corresponding `charset` parameter is now
used instead. Additionally, the docstring of `put-object` is changed
to reflect the actual semantics of the `:content-encoding` option.
