### PR TITLE
Make client creation more flexible.

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -1,12 +1,15 @@
 (ns aws.sdk.s3
   "Functions to access the Amazon S3 storage service.
 
-  Each function takes a map of credentials as its first argument. The
+  Each function takes an optional map of credentials, an AmazonS3Client, an
+  AWSCredentials, or an AWSCredentialsProvider as its first argument. The
   credentials map should contain an :access-key key and a :secret-key key."
   (:require [clojure.string :as str]
             [clj-time.core :as t]
             [clj-time.coerce :as coerce])
-  (:import com.amazonaws.auth.BasicAWSCredentials
+  (:import com.amazonaws.auth.AWSCredentials
+           com.amazonaws.auth.AWSCredentialsProvider
+           com.amazonaws.auth.BasicAWSCredentials
            com.amazonaws.services.s3.AmazonS3Client
            com.amazonaws.AmazonServiceException
            com.amazonaws.HttpMethod
@@ -29,17 +32,39 @@
            java.io.InputStream
            java.nio.charset.Charset))
 
+(defprotocol ^{:no-doc true} AmazonS3ClientFactory
+  "s3-client factory functions."
+  (^{:no-doc true} to-s3-client [x] "Returns an s3-client for x creating one if necessary."))
+
+(extend-protocol AmazonS3ClientFactory
+  AmazonS3Client
+  (to-s3-client [client] client)
+
+  AWSCredentials
+  (to-s3-client [aws-creds] (AmazonS3Client. aws-creds))
+
+  AWSCredentialsProvider
+  (to-s3-client [provider] (AmazonS3Client. provider))
+
+  clojure.lang.PersistentArrayMap
+  (to-s3-client [creds]
+    (AmazonS3Client.
+     (BasicAWSCredentials.
+      (:access-key creds)
+      (:secret-key creds))))
+
+  nil
+  (to-s3-client [_] (AmazonS3Client.)))
+
 (defn- s3-client*
-  "Create an AmazonS3Client instance from a map of credentials."
-  [cred]
-  (AmazonS3Client.
-   (BasicAWSCredentials.
-    (:access-key cred)
-    (:secret-key cred))))
+  "Create an AmazonS3Client instance."
+  ([] (to-s3-client nil))
+  ([x] (to-s3-client x)))
 
 (def ^{:private true}
   s3-client
   (memoize s3-client*))
+
 
 (defprotocol ^{:no-doc true} Mappable
   "Convert a value into a Clojure map."


### PR DESCRIPTION
This supports existing usage (e.g. passing creds as a map) and enables the
following scenarios:
- `AmazonS3Client` can be created and configured then used in place of `cred`
  This enables client configuration.
- `AWSCredentials` or `AWSCredentialsProvider` can be created and used in place of `cred` 
  This enables other types of auth like STS.
- `cred` can be nil, causing a new s3-client to be created which checks the default
  provider chain for creds and uses anonymous creds if none are found. (e.g. the default client
  behavior)

If this seems like overkill, allowing an `AmazonS3Client` anywhere `creds` are expected would also be fine.

Thanks for the great libraries!
