### PR TITLE
add a simple ensure-bucket fn for convenience

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -68,6 +68,11 @@
   [cred name]
   (to-map (.createBucket (s3-client cred) name)))
 
+(defn ensure-bucket
+  "Create a new S3 bucket if supplied bucket name does not exist."
+  [cred name]
+  (if-not (bucket-exists? cred name) (create-bucket cred name)))
+
 (defn delete-bucket
   "Delete the S3 bucket with the supplied name."
   [cred name]


### PR DESCRIPTION
I really like the `ensure-table` function available in your rotary lib and would find it useful if something similar was in clj-aws-s3 for buckets.

Since this library seems to be sticking to only what is available in the sdk, I'm not sure if this is a welcome addition - but it never hurts to try ;-)
