### PR TITLE
Integer arguments to s3 options map

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -106,6 +106,9 @@
   `(if-let [v# ~value]
      (~setter ~object v#)))
 
+(defn- maybe-int [x]
+  (if x (int x)))
+
 (defn- map->ObjectMetadata
   "Convert a map of object metadata into a ObjectMetadata instance."
   [metadata]
@@ -238,7 +241,7 @@
     (set-attr .setBucketName (:bucket request))
     (set-attr .setDelimiter  (:delimiter request))
     (set-attr .setMarker     (:marker request))
-    (set-attr .setMaxKeys    (:max-keys request))
+    (set-attr .setMaxKeys    (maybe-int (:max-keys request)))
     (set-attr .setPrefix     (:prefix request))))
 
 (defn- http-method [method]


### PR DESCRIPTION
This makes using integer options passed to S3 methods more pleasant from the REPL.

pre this PR, cast to int was required...

``` clojure
(s3/list-objects cred bucket {:max-keys (int 10)})
```

Now...

``` clojure
(s3/list-objects cred bucket {:max-keys 10})
```

Exceptions will still be raised it value is out of range, but that seems unlikely....
