### PR TITLE
maybe-int around max-results in list-versions

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -229,7 +229,7 @@
      :common-prefixes        (seq (.getCommonPrefixes listing))
      :delimiter              (.getDelimiter listing)
      :truncated?             (.isTruncated listing)
-     :max-results            (.getMaxKeys listing) ; AWS API is inconsistent, should be .getMaxResults
+     :max-results            (maybe-int (.getMaxKeys listing)) ; AWS API is inconsistent, should be .getMaxResults
      :key-marker             (.getKeyMarker listing)
      :next-key-marker        (.getNextKeyMarker listing)
      :next-version-id-marker (.getNextVersionIdMarker listing)


### PR DESCRIPTION
This Pull Request adds `maybe-int` handling for int args in the new list-versions in the same way as discussed in #24
