### PR TITLE
Added :session-token and :client-id to enable temporary session credentials

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,8 @@
 (defproject clj-aws-s3 "0.3.5"
   :description "Clojure Amazon S3 library."
   :dependencies [[org.clojure/clojure "1.2.1"]
+                 [org.clojure/core.cache "0.6.3"]
+                 [org.clojure/core.memoize "0.5.3"]
                  [com.amazonaws/aws-java-sdk "1.4.2.1"]
                  [clj-time "0.5.0"]]
   :plugins [[codox "0.6.4"]])

--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -4,15 +4,12 @@
   Each function takes a map of credentials as its first argument. The
   credentials map should contain an :access-key key and a :secret-key key,
   and optionally an :endpoint key to denote an AWS endpoint."
+  (:use [aws.sdk.s3.client :only (s3-client)])
   (:require [clojure.string :as str]
             [clj-time.core :as t]
             [clj-time.coerce :as coerce]
             [clojure.walk :as walk])
-  (:import com.amazonaws.auth.AWSCredentials
-           com.amazonaws.auth.BasicAWSCredentials
-           com.amazonaws.auth.BasicSessionCredentials
-           com.amazonaws.services.s3.AmazonS3Client
-           com.amazonaws.AmazonServiceException
+  (:import com.amazonaws.AmazonServiceException
            com.amazonaws.HttpMethod
            com.amazonaws.services.s3.model.AccessControlList
            com.amazonaws.services.s3.model.Bucket
@@ -36,25 +33,6 @@
            java.io.File
            java.io.InputStream
            java.nio.charset.Charset))
-
-(defn- ^AWSCredentials aws-creds
-  "Create an AWSCredentials implementation from a map of credentials."
-  [{:keys [access-key secret-key session-token]}]
-  (if session-token
-    (BasicSessionCredentials. access-key secret-key session-token)
-    (BasicAWSCredentials. access-key secret-key)))
-
-(defn- s3-client*
-  "Create an AmazonS3Client instance from a map of credentials."
-  [cred]
-  (let [client (AmazonS3Client. (aws-creds cred))]
-    (when-let [endpoint (:endpoint cred)]
-      (.setEndpoint client endpoint))
-    client))
-
-(def ^{:private true}
-  s3-client
-  (memoize s3-client*))
 
 (defprotocol ^{:no-doc true} Mappable
   "Convert a value into a Clojure map."

--- a/src/aws/sdk/s3/client.clj
+++ b/src/aws/sdk/s3/client.clj
@@ -1,0 +1,56 @@
+(ns aws.sdk.s3.client
+  (:use [clojure.core cache memoize])
+  (:import com.amazonaws.auth.AWSCredentials
+           com.amazonaws.auth.BasicAWSCredentials
+           com.amazonaws.auth.BasicSessionCredentials
+           com.amazonaws.services.s3.AmazonS3Client
+           clojure.core.memoize.PluggableMemoization))
+
+;; Defines a cache implementation which maps arguments to keys using the
+;; provided `key-for` function. The cached value for a given key is updated
+;; anytime the arguments change.
+(defcache KeyedCache [cache last-args-for key-for]
+  CacheProtocol
+  (lookup [_ args]
+    (get cache (key-for args)))
+  (lookup [_ args not-found]
+    (get cache (key-for args) not-found))
+  (has? [_ args]
+    (let [key (key-for args)]
+      (when-let [e (find last-args-for key)]
+        (and (= (val e) args) ; detect change in args
+             (contains? cache key)))))
+  (hit [this args] this)
+  (miss [_ args client]
+    (let [key (key-for args)]
+      (KeyedCache. (assoc cache key client)
+                    (assoc last-args-for key args)
+                    key-for)))
+  (evict [_ args]
+    (let [key (key-for args)]
+      (KeyedCache. (dissoc cache key) last-args-for key-for)))
+  (seed [_ base]
+    (KeyedCache. base (keys base) key-for)))
+
+(defn- keyed-client-cache []
+  (KeyedCache. {} {} (fn [[cred]] (get cred :client-id cred))))
+
+(defn- ^AWSCredentials aws-creds
+  "Create an AWSCredentials implementation from a map of credentials."
+  [{:keys [access-key secret-key session-token]}]
+  (if session-token
+    (BasicSessionCredentials. access-key secret-key session-token)
+    (BasicAWSCredentials. access-key secret-key)))
+
+(defn- s3-client*
+  "Create an AmazonS3Client instance from a map of credentials."
+  [cred]
+  (let [client (AmazonS3Client. (aws-creds cred))]
+    (when-let [endpoint (:endpoint cred)]
+      (.setEndpoint client endpoint))
+    client))
+
+(def ^AmazonS3Client s3-client
+  (build-memoizer
+   #(PluggableMemoization. % (keyed-client-cache))
+   s3-client*))

--- a/test/aws/sdk/s3/client_test.clj
+++ b/test/aws/sdk/s3/client_test.clj
@@ -1,0 +1,43 @@
+(ns aws.sdk.s3.client-test
+  (:use [aws.sdk.s3.client]
+        [clojure.test])
+  (:import com.amazonaws.services.s3.AmazonS3Client
+           com.amazonaws.auth.BasicAWSCredentials))
+
+(deftest amazon-s3-client-test
+  (testing "AmazonS3Client Constructor"
+    (let [cred (BasicAWSCredentials. "XYZ" "123")]
+      (is (not= (AmazonS3Client. cred) (AmazonS3Client. cred))
+          "returns different client for different args"))))
+
+(deftest s3-client-test
+  (testing "memoization without :client-id"
+    (let [cred {:access-key "XYZ" :secret-key "123"}]
+      (is (= (s3-client cred) (s3-client cred))
+          "returns the same object when given the same arguments"))
+
+    (let [cred1 {:access-key "XYZ" :secret-key "123"}
+          cred2 {:access-key "ABC" :secret-key "789"}]
+      (is (not (= (s3-client cred1) (s3-client cred2)))
+          "returns the different objects for different arguments")))
+
+  (testing "memoization with :client-id"
+    (let [cred {:access-key "XYZ" :secret-key "123" :client-id (Object.)}]
+      (is (= (s3-client cred) (s3-client cred))
+          "returns the same object when given the same arguments"))
+
+    (let [cred1 {:access-key "XYZ" :secret-key "123" :client-id (Object.)}
+          cred2 {:access-key "XYZ" :secret-key "123" :client-id (Object.)}]
+      (is (not (= (s3-client cred1) (s3-client cred2)))
+          "returns the different objects for different :client-id's"))
+
+    (let [id (Object.)
+          cred1 {:access-key "XYZ" :secret-key "123" :client-id id}
+          cred2 {:access-key "ABC" :secret-key "789" :client-id id}
+          client1 (s3-client cred1)
+          client2 (s3-client cred2)
+          client3 (s3-client cred1)]
+      (is (not (= client1 client2))
+          "returns the different objects for differnt arguments and the same :client-id")
+      (is (not (= client1 client3))
+          "caches only one client per :client-id"))))


### PR DESCRIPTION
AWS session credentials include a session token so which is now accepted in your `cred` map as `:session-token`.

Because `s3-client` uses `memoize` to cache clients and temporary session credentials are... temporary, it was necessary to improve the client caching strategy to avoid creating a new client every time the session credentials expire and get refreshed. See #15 for the full rationale.

The caching strategy used in this pull request, behaves just like the `memoize` solution, unless a `:client-id` is included in the `cred` map. The client-id is used as the cache key instead of the map itself so that only one client is cached for each client-id. When the client is cached, the arguments used to create it are cached as well and a new client is created when the arguments change.

This solution should continue to avoid issue #3 except in a very limited case where the same client-id is used on multiple threads and the first client gets booted from the cache and GC'd too soon. A better solution may be to return a reference to the client used for each request in the response so the caller can hold onto it until it's ok for the client to be GC'd.
