### PR TITLE
upload multipart from stream source

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-aws-s3 "0.3.7"
+(defproject caribou/clj-aws-s3 "0.3.7"
   :description "Clojure Amazon S3 library."
   :dependencies [[org.clojure/clojure "1.2.1"]
                  [com.amazonaws/aws-java-sdk "1.4.2.1"]

--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -217,18 +217,26 @@ Map may also contain the configuration keys :conn-timeout,
 
 (defn- upload-part
   [{cred :cred bucket :bucket key :key upload-id :upload-id
-    part-size :part-size offset :offset file :file}] 
-  (.getPartETag
-   (.uploadPart
-    (s3-client cred)
-    (doto (UploadPartRequest.)
+    part-size :part-size offset :offset file :file stream :stream}] 
+  (let [request (UploadPartRequest.)]
+    (doto request
       (.setBucketName bucket)
       (.setKey key)
       (.setUploadId upload-id)
       (.setPartNumber (+ 1 (/ offset part-size)))
-      (.setFileOffset offset)
-      (.setPartSize (min part-size (- (.length file) offset)))
-      (.setFile file)))))
+      (.setFileOffset offset))
+    (if file
+      ;; either file or stream must be passed in
+      (doto request
+        (.setPartSize (min part-size (- (.length file) offset)))
+        (.setFile file))
+      (doto request
+        (.setPartSize (min part-size (.available stream)))
+        (.setInputStream stream)))
+    (.getPartETag
+     (.uploadPart
+      (s3-client cred)
+      request))))
 
 (defn put-multipart-object
   "Do a multipart upload of a file into a S3 bucket at the specified key.
@@ -257,6 +265,33 @@ Map may also contain the configuration keys :conn-timeout,
         (.shutdown pool)
         (throw ex))
       (finally (.shutdown pool)))))
+
+(defn put-multipart-stream
+  "Like put-multipart-object, but it is single threaded and uses an input-stream
+   instead of a file as the data source. The single threading is intentional,
+   to allow for a future design where the input stream can lock in case upload
+   is faster than stream generation."
+  [cred bucket key input &[{:keys [part-size lock]
+                            :or {part-size (* 5 1024 1024)
+                                 lock (Object.)}}]]
+  (let [part-size (max 1024 (min (.available input) part-size))
+        upload-id (initiate-multipart-upload cred bucket key)
+        upload {:upload-id upload-id
+                :cred cred
+                :bucket bucket
+                :key key
+                :stream input}
+        e-tags (loop [offset 0 e-tags []]
+                 (if (zero? (.available input))
+                   ;; TODO: know when to wait for the stream instead of finishing
+                   (java.util.ArrayList. e-tags)
+                   (let [e-tag (upload-part (assoc upload :offset offset :part-size part-size))]
+                     (recur (inc offset) (conj e-tags e-tag)))))]
+    (try
+      (complete-multipart-upload (assoc upload :e-tags e-tags))
+      (catch Exception ex
+        (abort-multipart-upload upload)
+        (throw ex)))))
 
 (extend-protocol Mappable
   S3Object


### PR DESCRIPTION
this modification allows uploading to s3 from a stream source, without needing to know the size of the upload before starting

(sorry about the group change in project.clj - I don't know the github pull request UI well enough to exclude that from the request)
