### PR TITLE
type hints to remove reflection warnings

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -42,7 +42,7 @@
            java.io.InputStream
            java.nio.charset.Charset))
 
-(defn- s3-client* 
+(defn- s3-client*
   "Create an AmazonS3Client instance from a map of credentials.
 
 Map may also contain the configuration keys :conn-timeout,


### PR DESCRIPTION
Greetings,
I've added sufficient type hints to remove the reflection warnings for clj-aws-s3.  I believe this is the minimum set of type hints to remove the warnings.  I've tested with the subset of clj-aws-s3 functionality that I use, but I don't use the full set.  Specifically, I don't use the multipart upload functionality, nor do I use acls (I handle all the permissions downstream).

Thanks for a powerful, simple and elegant set of Clojure tools.
-Chris
