### PR TITLE
Determine whether a bucket exists in your account

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -95,6 +95,12 @@ Map may also contain the configuration keys :conn-timeout,
   [cred name]
   (.doesBucketExist (s3-client cred) name))
 
+(defn bucket-exists-in-account?
+  "Returns true if the supplied bucket name already exists in
+  your account".
+  [cred name]
+  (some #{name} (map :name (s3/list-buckets cred))))
+
 (defn create-bucket
   "Create a new S3 bucket with the supplied name."
   [cred ^String name]


### PR DESCRIPTION
Offers a function not in the AWS sdk which is to determine whether you have a bucket in your account, rather than bucket-exists? which tests whether the bucket exists at all anywhere.

AWS docs define bucketExists as "Checks if the specified bucket exists. Amazon S3 buckets are named in a global namespace; use this method to determine if a specified bucket name already exists, and therefore can't be used to create a new bucket." where as it defines listBuckets as "Returns a list of all Amazon S3 buckets that the authenticated sender of the request owns."

The use case for this function is to enable different decision points depending on whether you own and have access to a bucket vs the bucket already exists and is owned by someone else.
