### PR TITLE
Support path-style access URLs

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -15,6 +15,7 @@
   (:import com.amazonaws.auth.BasicAWSCredentials
            com.amazonaws.auth.BasicSessionCredentials
            com.amazonaws.services.s3.AmazonS3Client
+           com.amazonaws.services.s3.S3ClientOptions
            com.amazonaws.AmazonServiceException
            com.amazonaws.ClientConfiguration
            com.amazonaws.HttpMethod
@@ -80,6 +81,9 @@
           client (AmazonS3Client. aws-creds client-configuration)]
       (when-let [endpoint (:endpoint cred)]
         (.setEndpoint client endpoint))
+      (when-let [path-style-access? (:path-style-access? cred)]
+        (->> (.withPathStyleAccess (S3ClientOptions.) path-style-access?)
+             (.setS3ClientOptions client)))
       client)))
 
 (def ^{:private true :tag AmazonS3Client}


### PR DESCRIPTION
There are two ways to generate S3 object URLs, virtual-hosted style
URLs vs. path-style URLs [1](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html):
- Virtual-hosted-style: `http://bucket.s3.amazonaws.com`
- Path-style: `http://s3.amazonaws.com/bucket`

Virtual-hosted-style is Amazon's preferred default, however HTTPS is
not compatible with all virtual-hosted-style URLs.  Specifically,
virtual-hosted-style buckets with dots in their names always cause
HTTPS cert validation errors, as per RFC 2818 [2](http://shlomoswidler.com/2009/08/amazon-s3-gotcha-using-virtual-host.html):

```
https://foo.bar.s3.amazonaws.com/key
```

Path-style access works fine with HTTPS, without forcing a bucket rename:

```
https://s3.amazonaws.com/foo.bar/key
```

This commit allows configuring the client for path-style access via
the cred map:

```
(let [cred {:access-key ...
            :secret-key ...
            :path-style-access? true}]
  (generate-presigned-url cred bucket key))
```

Note that when using path style access you may need to manually specify your
region-specific S3 endpoint [1](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html):

```
(let [cred {...
            :path-style-access? true
            :endpoint "s3-us-west-1.amazonaws.com"}]
  ...)
```
