### PR TITLE
Added support for using default credentials provider when no access-key or secret-key specified

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -14,6 +14,7 @@
             [clojure.walk :as walk])
   (:import com.amazonaws.auth.BasicAWSCredentials
            com.amazonaws.auth.BasicSessionCredentials
+           com.amazonaws.auth.DefaultAWSCredentialsProviderChain
            com.amazonaws.services.s3.AmazonS3Client
            com.amazonaws.AmazonServiceException
            com.amazonaws.ClientConfiguration
@@ -73,10 +74,11 @@
     (when-let [proxy-workstation (get-in cred [:proxy :workstation])]
       (.setProxyWorkstation client-configuration proxy-workstation))
     (let [aws-creds
-          (if (:token cred)
-            (BasicSessionCredentials. (:access-key cred) (:secret-key cred) (:token cred))
-            (BasicAWSCredentials. (:access-key cred) (:secret-key cred)))
-
+          (if (and (:access-key cred) (:secret-key cred))
+            (if (:token cred)
+              (BasicSessionCredentials. (:access-key cred) (:secret-key cred) (:token cred))
+              (BasicAWSCredentials. (:access-key cred) (:secret-key cred)))
+            (DefaultAWSCredentialsProviderChain.))
           client (AmazonS3Client. aws-creds client-configuration)]
       (when-let [endpoint (:endpoint cred)]
         (.setEndpoint client endpoint))


### PR DESCRIPTION
When credentials map does not specify access key or secret key, uses DefaultAWSCredentialsProviderChain to auto-supply credentials.
