### PR TITLE
JC: Support vanilla multi-object delete

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -23,6 +23,9 @@
            com.amazonaws.services.s3.model.Grant
            com.amazonaws.services.s3.model.CanonicalGrantee
            com.amazonaws.services.s3.model.CopyObjectResult
+           com.amazonaws.services.s3.model.DeleteObjectsRequest
+           com.amazonaws.services.s3.model.DeleteObjectsResult
+           com.amazonaws.services.s3.model.DeleteObjectsResult$DeletedObject
            com.amazonaws.services.s3.model.EmailAddressGrantee
            com.amazonaws.services.s3.model.GetObjectRequest
            com.amazonaws.services.s3.model.GetObjectMetadataRequest
@@ -343,7 +346,16 @@
      :expiration-time         (.getExpirationTime result)
      :expiration-time-rule-id (.getExpirationTimeRuleId result)
      :last-modified-date      (.getLastModifiedDate result)
-     :server-side-encryption  (.getServerSideEncryption result)}))
+     :server-side-encryption  (.getServerSideEncryption result)})
+  DeleteObjectsResult
+  (to-map [result]
+    {:objects (map to-map (.getDeletedObjects result))})
+  DeleteObjectsResult$DeletedObject
+  (to-map [object]
+    {:delete-marker-version-id (.getDeleteMarkerVersionId object)
+     :delete-marker?           (.isDeleteMarker object)
+     :key                      (.getKey object)
+     :version-id               (.getVersionId object)}))
 
 (defn get-object
   "Get an object from an S3 bucket. The object is returned as a map with the
@@ -446,6 +458,16 @@
   "Delete an object from an S3 bucket."
   [cred bucket key]
   (.deleteObject (s3-client cred) bucket key))
+
+(defn delete-objects
+  "Delete objects from an S3 bucket. A optional map of options may be supplied.
+  Available options are:
+  :quiet - Suppress responses from S3"
+  [cred bucket keys & [{:keys [quiet]}]]
+  (let [request (-> (DeleteObjectsRequest. bucket)
+                    (.withQuiet (boolean quiet))
+                    (.withKeys (into-array keys)))] ; No AWS .setKeys(string...)
+    (to-map (.deleteObjects (s3-client cred) request))))
 
 (defn object-exists?
   "Returns true if an object exists in the supplied bucket and key."


### PR DESCRIPTION
This PR adds basic support for multi-object delete.

``` clojure
user=> (require '[aws.sdk.s3 :as s3])
nil
user=> (s3/delete-objects aws-credentials "my-bucket" ["foo" "bar" "baz"])
{:objects ({:delete-marker-version-id nil, :delete-marker? false, :key "bar", :version-id nil} {:delete-marker-version-id nil, :delete-marker? false, :key "foo", :version-id nil} {:delete-marker-version-id nil, :delete-marker? false, :key "baz", :version-id nil})}
user=> (s3/delete-objects aws-credentials "my-bucket" ["foo" "bar" "baz"] {:quiet true})
{:objects ()}
```

I didn't attempt to handle it here, but if there are opinions or precedent on dealing with request limits (for example, the 1000 object limit for multi-object delete), I'm happy to address them. At the moment, my application code is handling the partitioning of keys to respect the object limit, but that logic might have a place in this library instead.

Another potential TODO item is handling multi-object delete for versioned objects.
