### PR TITLE
Updating aws sdk

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [com.amazonaws/aws-java-sdk "1.7.5"]
+                 [com.amazonaws/aws-java-sdk "1.10.22"]
                  [clj-time "0.6.0"]]
   :plugins [[codox "0.8.10"]])


### PR DESCRIPTION
We are having some issues with 0 byte files so part of a debug step we are doing is updating the base aws sdk to latest.  There appear to have been a number of fairly serious bugs fixed since 1.7.5 (e.g. Fix unintended AbortedException when TransferManager is garbage collected.).

Tested put-object, get-object, and delete-object calls.