### PR TITLE
Fall back to DefaultAWSCredentialsProviderChain if credentials does not contain a :token or :access-key

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -14,6 +14,7 @@
             [clojure.walk :as walk])
   (:import com.amazonaws.auth.BasicAWSCredentials
            com.amazonaws.auth.BasicSessionCredentials
+           com.amazonaws.auth.DefaultAWSCredentialsProviderChain
            com.amazonaws.services.s3.AmazonS3Client
            com.amazonaws.AmazonServiceException
            com.amazonaws.ClientConfiguration
@@ -73,10 +74,13 @@
     (when-let [proxy-workstation (get-in cred [:proxy :workstation])]
       (.setProxyWorkstation client-configuration proxy-workstation))
     (let [aws-creds
-          (if (:token cred)
-            (BasicSessionCredentials. (:access-key cred) (:secret-key cred) (:token cred))
-            (BasicAWSCredentials. (:access-key cred) (:secret-key cred)))
-
+          (cond
+            (:token cred)
+              (BasicSessionCredentials. (:access-key cred) (:secret-key cred) (:token cred))
+            (:access-key cred)
+              (BasicAWSCredentials. (:access-key cred) (:secret-key cred))
+            :else
+              (DefaultAWSCredentialsProviderChain.))
           client (AmazonS3Client. aws-creds client-configuration)]
       (when-let [endpoint (:endpoint cred)]
         (.setEndpoint client endpoint))


### PR DESCRIPTION
Hi James,

Would you consider merging this pull request?

I ran into an issue where our servers are relying on instance profile credentials in the Amazon EC2 metadata service for authentication. In this case the credentials map supplied to your library contains neither a :token nor an :access-key so I have changed the code to fall back to using the DefaultAWSCredentialsProviderChain which will use the metadata service to get authentication information if it can't find credentials elsewhere. The rules are documented here: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html

Does this sound reasonable to you?

Cheers,
Dean.