### PR TITLE
constraints in copy-object, get-object; process put-object result

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -372,9 +372,22 @@
   If these rules are not followed, the client can run out of resources by
   allocating too many open, but unused, HTTP connections."
   ([cred ^String bucket ^String key]
-     (to-map (.getObject (s3-client cred) bucket key)))
-  ([cred ^String bucket ^String key ^String version-id]
-     (to-map (.getObject (s3-client cred) (GetObjectRequest. bucket key version-id)))))
+   (to-map (.getObject (s3-client cred) bucket key)))
+  ;  ([cred ^String bucket ^String key ^String version-id]
+  ;    (to-map (.getObject (s3-client cred) (GetObjectRequest. bucket key version-id)))))
+  ([cred ^String bucket ^String key {:keys [version-id matching-etags nonmatching-etags modified-since unmodified-since] :as opts}]
+   (let [req (GetObjectRequest. bucket key)]
+     (when version-id
+       (.setVersionId req version-id))
+     (when matching-etags
+       (.setMatchingETagConstraints req matching-etags))
+     (when nonmatching-etags
+       (.setNonmatchingETagConstraints req nonmatching-etags))
+     (when modified-since
+       (.setModifiedSinceConstraint req modified-since))
+     (when unmodified-since
+       (.setUnmodifiedSinceConstraint req unmodified-since))
+     (to-map (.getObject (s3-client cred) req)))))
 
 (defn- map->GetObjectMetadataRequest
   "Create a ListObjectsRequest instance from a map of values."

--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -22,6 +22,7 @@
            com.amazonaws.services.s3.model.Bucket
            com.amazonaws.services.s3.model.Grant
            com.amazonaws.services.s3.model.CanonicalGrantee
+           com.amazonaws.services.s3.model.CopyObjectRequest
            com.amazonaws.services.s3.model.CopyObjectResult
            com.amazonaws.services.s3.model.EmailAddressGrantee
            com.amazonaws.services.s3.model.GetObjectRequest
@@ -35,6 +36,7 @@
            com.amazonaws.services.s3.model.ObjectListing
            com.amazonaws.services.s3.model.Permission
            com.amazonaws.services.s3.model.PutObjectRequest
+           com.amazonaws.services.s3.model.PutObjectResult
            com.amazonaws.services.s3.model.S3Object
            com.amazonaws.services.s3.model.S3ObjectSummary
            com.amazonaws.services.s3.model.S3VersionSummary
@@ -214,7 +216,7 @@
                  (->PutObjectRequest bucket key))]
     (when permissions
       (.setAccessControlList req (create-acl permissions)))
-    (.putObject (s3-client cred) req)))
+    (to-map (.putObject (s3-client cred) req))))
 
 (defn- initiate-multipart-upload
   [cred bucket key] 
@@ -343,7 +345,15 @@
      :expiration-time         (.getExpirationTime result)
      :expiration-time-rule-id (.getExpirationTimeRuleId result)
      :last-modified-date      (.getLastModifiedDate result)
-     :server-side-encryption  (.getServerSideEncryption result)}))
+     :server-side-encryption  (.getServerSideEncryption result)})
+  PutObjectResult
+  (to-map [result]
+    {:versionId               (.getVersionId result)
+     :etag                    (.getETag result)
+     :server-side-encryption  (.getServerSideEncryption result)
+     :expiration-time         (.getExpirationTime result)
+     :expiration-time-rule-id (.getExpirationTimeRuleId result)
+     :content-md5             (.getContentMd5 result)}))
 
 (defn get-object
   "Get an object from an S3 bucket. The object is returned as a map with the
@@ -464,7 +474,18 @@
   ([cred bucket src-key dest-key]
      (copy-object cred bucket src-key bucket dest-key))
   ([cred src-bucket src-key dest-bucket dest-key]
-     (to-map (.copyObject (s3-client cred) src-bucket src-key dest-bucket dest-key))))
+     (to-map (.copyObject (s3-client cred) src-bucket src-key dest-bucket dest-key)))
+  ([cred src-bucket src-key dest-bucket dest-key {:keys [matching-etags nonmatching-etags modified-since unmodified-since] :as opts}]
+     (let [req (CopyObjectRequest. src-bucket src-key dest-bucket dest-key)]
+       (when matching-etags
+         (.setMatchingETagConstraints req matching-etags))
+       (when nonmatching-etags
+         (.setNonmatchingETagConstraints req nonmatching-etags))
+       (when modified-since
+         (.setModifiedSinceConstraint req modified-since))
+       (when unmodified-since
+         (.setUnmodifiedSinceConstraint req unmodified-since))
+     (to-map (.copyObject (s3-client cred) req)))))
 
 (defn- map->ListVersionsRequest
   "Create a ListVersionsRequest instance from a map of values."


### PR DESCRIPTION
This PR accomplishes two things:

Modify get-object and copy-object to support the matchingEtags, nonmatchingEtags, modifiedSince, and unmodifiedSince constriants (defined in AWS's GetObjectRequest and CopyObjectRequest).

Modify put-object and the (extend-protocol Mappable... form to support converting the PutObjectResult object to a map that gets returned from put-object.

Note there is a API breaking change in get-object: to take options, I had to replace the function overload that takes a version-id.  I added version-id as an option, but this may break existing code that relies on being able to pass a naked version-id as the third parameter.  If this is unacceptable, please suggest an alternative and I'll modify the PR.