### PR TITLE
Add the ability to use the default credentials provider.

### DIFF
--- a/src/aws/sdk/s3.clj
+++ b/src/aws/sdk/s3.clj
@@ -73,11 +73,15 @@
     (when-let [proxy-workstation (get-in cred [:proxy :workstation])]
       (.setProxyWorkstation client-configuration proxy-workstation))
     (let [aws-creds
-          (if (:token cred)
-            (BasicSessionCredentials. (:access-key cred) (:secret-key cred) (:token cred))
-            (BasicAWSCredentials. (:access-key cred) (:secret-key cred)))
-
-          client (AmazonS3Client. aws-creds client-configuration)]
+          (cond (every? cred [:token :access-key :secret-key])
+                (BasicSessionCredentials.
+                 (:access-key cred) (:secret-key cred) (:token cred))
+                (every? cred [:access-key :secret-key])
+                (BasicAWSCredentials. (:access-key cred) (:secret-key cred))
+                :else nil)
+          client (if aws-creds
+                   (AmazonS3Client. aws-creds client-configuration)
+                   (AmazonS3Client. client-configuration))]
       (when-let [endpoint (:endpoint cred)]
         (.setEndpoint client endpoint))
       client)))


### PR DESCRIPTION
There is a nice feature in the AWS SDK that will allow you to use the [DefaultAWSCredentialsProviderChain](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html).

The DefaultAWSCredentialsProviderChain looks for credentials in the following order:

- Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
- Java System Properties - aws.accessKeyId and aws.secretKey
- Credential profiles file at the default location (~/.aws/credentials)
- Instance profile credentials delivered through the Amazon EC2 metadata service

The last one will allow you to use IAM roles and policies to grant access to S3 without providing credentials.